### PR TITLE
Fix BMI verdict condition and add 'others' option for gender in PatientUpdate

### DIFF
--- a/main.py
+++ b/main.py
@@ -31,7 +31,7 @@ class Patient(BaseModel):
         elif self.bmi < 25:
             return 'Normal'
         elif self.bmi < 30:
-            return 'Normal'
+            return 'Overweight'
         else:
             return 'Obese'
         
@@ -39,7 +39,7 @@ class PatientUpdate(BaseModel):
     name: Annotated[Optional[str], Field(default=None)]
     city: Annotated[Optional[str], Field(default=None)]
     age: Annotated[Optional[int], Field(default=None, gt=0)]
-    gender: Annotated[Optional[Literal['male', 'female']], Field(default=None)]
+    gender: Annotated[Optional[Literal['male', 'female', 'others']], Field(default=None)]
     height: Annotated[Optional[float], Field(default=None, gt=0)]
     weight: Annotated[Optional[float], Field(default=None, gt=0)]
 


### PR DESCRIPTION
Fixed BMI verdict condition and added an option for “others” in gender selections.